### PR TITLE
Add node_modules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 /config/master.key
 
 .env.sh
+
+/node_modules

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This is a Rails 7 with Hotwire project.
 
 `bundle exec rake db:create db:migrate`
 
+`yarn install`
+
 `bundle exec rails s`
 
 Go to:


### PR DESCRIPTION
When ran **yarn install**. 

before: 
![image](https://github.com/user-attachments/assets/c4a138bb-a9a2-4d2f-b193-23aa305720b7)


after: 
![image](https://github.com/user-attachments/assets/b8acead6-ea55-4d54-b974-e58e5ee42ef3)

**obs:** if this can generate some problem in production, please don't merge
