### PR TITLE
Add button helper class

### DIFF
--- a/app/helpers/buttons_mobile_helper.rb
+++ b/app/helpers/buttons_mobile_helper.rb
@@ -1,0 +1,8 @@
+module ButtonsMobileHelper
+  def responsive_form_submit(form, value, classes)
+    safe_join([
+      form.submit(value, class: "#{classes} w-100 d-block d-md-none"),
+      form.submit(value, class: "#{classes} d-none d-md-block")
+    ])
+  end
+end  

--- a/app/views/quizer/alternatives/edit.html.slim
+++ b/app/views/quizer/alternatives/edit.html.slim
@@ -7,4 +7,4 @@ h2 Editing alternative
 = form_with(model: [@quiz, @question, @alternative], url: quizer_quiz_question_alternative_path) do |form|
   = render "form", alternative: @alternative, form: form
 
-  = form.submit 'Save', class: 'btn btn-primary btn-lg'
+  = responsive_form_submit(form, 'Save', 'btn btn-primary btn-lg')

--- a/app/views/quizer/alternatives/new.html.slim
+++ b/app/views/quizer/alternatives/new.html.slim
@@ -5,5 +5,7 @@ h3 New alternative
 = form_with(model: [@quiz, @question, @alternative], url: quizer_quiz_question_alternatives_path) do |form|
   = render "form", alternative: @alternative, form: form
 
-  = form.submit 'Save and go back', class: 'btn btn-primary btn-lg me-2'
-  = form.submit 'Save and create a new one', class: 'btn btn-secondary btn-lg'
+  div.d-flex.flex-wrap.gap-2
+    = responsive_form_submit(form, 'Save and create a new one', 'btn btn-secondary btn-lg')
+    = responsive_form_submit(form, 'Save and go back', 'btn btn-primary btn-lg')
+    

--- a/app/views/quizer/questions/_form.html.slim
+++ b/app/views/quizer/questions/_form.html.slim
@@ -11,4 +11,4 @@
   = form.text_area :description, class: 'form-control', rows: 7,
     placeholder: Quizer::Question::DESCRIPTION_SURVEY_EXAMPLE
 
-= form.submit 'Save', class: 'btn btn-primary btn-lg'
+= responsive_form_submit(form, 'Save', 'btn btn-primary btn-lg')

--- a/app/views/quizer/quizzes/_form.html.slim
+++ b/app/views/quizer/quizzes/_form.html.slim
@@ -12,4 +12,5 @@
       placeholder: Quizer::Quiz::DESCRIPTION_SURVEY_EXAMPLE
 
     .mt-2.text-center
-      = form.submit 'Save', class: 'btn btn-primary btn-lg'
+      = responsive_form_submit(form, 'Save', 'btn btn-primary btn-lg')
+

--- a/spec/helpers/buttons_mobile_helper_spec.rb
+++ b/spec/helpers/buttons_mobile_helper_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe ButtonsMobileHelper do
+  describe "#responsive_form_submit" do
+    let(:form) { double("form") }
+    let(:value) { "Submit" }
+    let(:classes) { "btn btn-primary" }
+
+    it "renders the submit button with appropriate classes for mobile and desktop" do
+      expect(form).to receive(:submit).with(value, class: "#{classes} w-100 d-block d-md-none")
+      expect(form).to receive(:submit).with(value, class: "#{classes} d-none d-md-block")
+
+      helper.responsive_form_submit(form, value, classes)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a button helper class to render w-100 on mobile devices.  This is a proof of concept; there might be a better approach. If you're not satisfied  with it, please don't merge.

**/questions/new desktop:** 
![image](https://github.com/user-attachments/assets/7c4cf2c0-8eee-4495-9a81-26820945a355)

**/questions/new mobile:** 
![image](https://github.com/user-attachments/assets/1c86a632-166b-4db2-9cc1-0642fb46693e)

**/questions/edit desktop:** 
![image](https://github.com/user-attachments/assets/8fab86d9-2cc7-4ba7-9afb-69c168b9a352)


**/questions/edit mobile:** 
![image](https://github.com/user-attachments/assets/5afcabdb-f311-4aa8-a742-b12d840b20d0)

**/alternatives desktop:** 
![image](https://github.com/user-attachments/assets/8ffb09a5-bbbd-4084-b56b-5b3010aeb382)

**/alternatives mobile:** 
![image](https://github.com/user-attachments/assets/be6ebe46-e122-47a5-a550-778163f5a9d1)




